### PR TITLE
feat: add structured JSON logging for cloud environments

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,3 @@
+.env
+.env.local
+*.secret

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1725,6 +1725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,12 +1744,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tower-http = { version = "0.6.8", features = ["cors", "trace", "fs"] }
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt", "ansi"] }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt", "ansi", "json"] }
 chrono = { version = "0.4.43", features = ["serde"] }
 anyhow = "1.0.100"
 octocrab = "0.40.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -85,13 +85,22 @@ async fn main() {
 }
 
 fn init_tracing() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "backend=debug,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "backend=debug,tower_http=debug".into());
+
+    let log_format = std::env::var("LOG_FORMAT").unwrap_or_default();
+
+    if log_format == "json" {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().json().with_ansi(false))
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+    }
 }
 
 async fn get_listener() -> tokio::net::TcpListener {


### PR DESCRIPTION
Updates tracing configuration to support LOG_FORMAT=json. When enabled, logs are emitted as JSON without ANSI colors, which is the native format for Google Cloud Logging.