### PR TITLE
feat: distinguish widening vs tightening spread

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,7 +151,7 @@ function App(): JSX.Element {
               value={summary.current_spread}
               trend={summary.is_widening ? TrendDirection.UP : TrendDirection.DOWN}
               trendLabel={summary.is_widening ? 'Widening' : 'Tightening'}
-              color="bg-main"
+              color={summary.is_widening ? 'bg-red-400' : 'bg-main'}
               description="Difference between opened and merged PRs. A widening spread means the backlog is growing."
             />
             <StatCard

--- a/frontend/src/components/FlowChart.tsx
+++ b/frontend/src/components/FlowChart.tsx
@@ -69,6 +69,15 @@ export const FlowChart = ({ data }: FlowChartProps): JSX.Element => {
             activeDot={{ r: 8 }}
             name="PRs Merged"
           />
+          <Line
+            type="monotone"
+            dataKey="spread"
+            stroke="#000"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={false}
+            name="The Spread"
+          />
         </LineChart>
       </ResponsiveContainer>
     </Card>


### PR DESCRIPTION
Updates the UI to provide better visual feedback on the PR flow spread.

- The Spread card now turns red when the spread is widening (backlog growing).
- A new dashed line representing the calculated spread has been added to the main chart.

Closes #44