### PR TITLE
docs: update agent guidelines with PR naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
   - Frontend: `npm run lint`, `npm run build`, `npm test`. ALWAYS run `npm run format` to ensure code is formatted correctly.
 - **Minimal Comments.** Only add comments if they explain *why* a complex piece of logic exists. Do not add comments describing *what* the code is doing (e.g., avoid `// Start server` or `// Define routes`).
 - **Configuration.** The backend uses the 12-factor app methodology. Configuration is loaded from environment variables using `AppConfig`. Do not hardcode constants for configuration.
+- **PR Naming.** Use [Conventional Commits](https://www.conventionalcommits.org/) for PR titles (e.g., `feat: ...`, `fix: ...`). In the PR body, include a brief description and explicitly close linked issues using `Closes #123`. Do not include "Implements issue #..." in the title.


### PR DESCRIPTION
Adds specific instructions for PR naming and body formatting to AGENTS.md to ensure consistency across contributions.