### PR TITLE
fix: prevent race conditions with request cancellation

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -29,7 +29,7 @@ describe('App', () => {
     fireEvent.click(button)
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith('empty', 'repo')
+      expect(fetchSpy).toHaveBeenCalledWith('empty', 'repo', expect.anything())
     })
 
     const noDataMessage = await screen.findByText(/No data found/i)

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fetchRepoMetrics } from './api'
+
+describe('fetchRepoMetrics', () => {
+  const fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+
+  afterEach(() => {
+    fetchSpy.mockReset()
+  })
+
+  it('calls fetch with correct URL', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    })
+
+    await fetchRepoMetrics('owner', 'repo')
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos/owner/repo/metrics', { signal: undefined })
+  })
+
+  it('passes abort signal to fetch', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    })
+
+    const controller = new AbortController()
+    await fetchRepoMetrics('owner', 'repo', controller.signal)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/repos/owner/repo/metrics'),
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
+    )
+  })
+})

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -5,14 +5,17 @@ import type { RepoMetricsResponse, PopularRepo } from '../types'
  *
  * @param owner - The GitHub username or organization.
  * @param repo - The repository name.
+ * @param signal - Optional AbortSignal to cancel the request.
  * @returns A promise that resolves to a RepoMetricsResponse object.
  */
 export const fetchRepoMetrics = async (
   owner: string,
   repo: string,
+  signal?: AbortSignal,
 ): Promise<RepoMetricsResponse> => {
   const response = await fetch(
     `/api/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/metrics`,
+    { signal },
   )
 
   if (!response.ok) {


### PR DESCRIPTION
Implements request cancellation using AbortController to fix race conditions when switching repos rapidly.

- Modifies `fetchRepoMetrics` to accept an `AbortSignal`.
- Updates `App.tsx` to cancel previous pending requests before starting a new one.
- Adds unit tests for API and updates existing App tests.

Closes #45